### PR TITLE
Use the command when matching to regex, not the bot name

### DIFF
--- a/src/acl.coffee
+++ b/src/acl.coffee
@@ -47,8 +47,12 @@ regex = (robot)->
       modifiers
     )
   else
+    newName = ""
+    for i in [0..name.length-1]
+      newName += ("[#{name.charAt(i).toLowerCase()}#{name.charAt(i).toUpperCase()}]")
+
     newRegex = new RegExp(
-      "^\\s*[@]?#{name}[:,]?\\s*(#{pattern})",
+      "^\\s*[@]?(#{newName})[:,]?\\s*(#{pattern})",
       modifiers
     )
   newRegex

--- a/src/acl.coffee
+++ b/src/acl.coffee
@@ -59,7 +59,7 @@ module.exports = (robot)->
 
   robot.listeners.unshift new TextListener robot, regex, (msg)->
     user = msg.message.user
-    text = msg.match[1]
+    text = msg.match[2]
     role = if robot.auth then robot.auth.userRoles(user) else []
 
     robot.logger.debug "[hubot-acl] acl check start"


### PR DESCRIPTION
match[1] is the name of the bot. match[2] is the command.

Also, if a command was case insensitive and someone wrote something like
"hubot command" when the bot's name was Hubot, no authentication
occurred.
